### PR TITLE
Don't panic or log fatal in the library code

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -74,7 +74,7 @@ func parseMessage(buffer []byte, length int) (interface{}, error) {
 // Quick sanity check that we parsed all of the message bytes
 func (p *parser) checkParse(message interface{}) error {
 	if p.cursor != p.length {
-		return fmt.Errorf("Parsing WSJT-X %s: There were %d bytes left over\n",
+		return fmt.Errorf("parsing WSJT-X %s: there were %d bytes left over",
 			reflect.TypeOf(message).Name(), p.length-p.cursor)
 	}
 	return nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -141,7 +141,11 @@ func TestParseMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseMessage(tt.args.buffer, tt.args.length); !reflect.DeepEqual(got, tt.want) {
+			got, err := parseMessage(tt.args.buffer, tt.args.length)
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseMessage() = %v, want %v", got, tt.want)
 			}
 		})

--- a/server.go
+++ b/server.go
@@ -14,13 +14,17 @@ const wsjtxPort = "2237"
 type Server struct {
 	conn       *net.UDPConn
 	remoteAddr *net.UDPAddr
+	listening  bool
 }
 
-// Create a UDP connection to communicate with WSJT-X.
+// MakeServer creates a multicast UDP connection to communicate with WSJT-X on the default address
+// and port.
 func MakeServer() (Server, error) {
 	return MakeMulticastServer(multicastAddr, wsjtxPort)
 }
 
+// MakeMulticastServer creates a multicast UDP connection to communicate with WSJT-X on the given
+// address and port.
 func MakeMulticastServer(addrStr string, portStr string) (Server, error) {
 	var empty Server
 	addr, err := net.ResolveUDPAddr("udp", addrStr+":"+portStr)
@@ -31,9 +35,11 @@ func MakeMulticastServer(addrStr string, portStr string) (Server, error) {
 	if err != nil {
 		return empty, err
 	}
-	return Server{conn, nil}, nil
+	return Server{conn, nil, false}, nil
 }
 
+// MakeUnicastServer creates a unicast UDP connection to communicate with WSJT-X on the given
+// address and port.
 func MakeUnicastServer(addrStr string, portStr string) (Server, error) {
 	var empty Server
 	addr, err := net.ResolveUDPAddr("udp", addrStr+":"+portStr)
@@ -44,97 +50,115 @@ func MakeUnicastServer(addrStr string, portStr string) (Server, error) {
 	if err != nil {
 		return empty, err
 	}
-	return Server{conn, nil}, nil
+	return Server{conn, nil, false}, nil
 }
 
-// Goroutine to listen for messages from WSJT-X. When heard, the messages are
-// parsed and then placed in the given channel.
-func (s *Server) ListenToWsjtx(c chan interface{}) {
+// ListenToWsjtx listens for messages from WSJT-X. When heard, the messages are parsed and then
+// placed in the given message channel. If parsing errors occur, those are reported on the errors
+// channel. If a fatal error happens, e.g. the network connection gets closed, the channels are
+// closed and the goroutine ends.
+func (s *Server) ListenToWsjtx(c chan interface{}, e chan error) {
+	s.listening = true
+	defer close(c)
+	defer close(e)
+
 	for {
 		b := make([]byte, bufLen)
 		length, rAddr, err := s.conn.ReadFromUDP(b)
-		c <- err
+		if err != nil {
+			e <- err
+			s.listening = false
+			return
+		}
 		s.remoteAddr = rAddr
 		message, err := parseMessage(b, length)
+		if err != nil {
+			e <- err
+		}
 		if message != nil {
 			c <- message
 		}
 	}
 }
 
-// Send a heartbeat message to WSJT-X.
+// Listening returns whether the ListenToWsjtx goroutine is currently running.
+func (s *Server) Listening() bool {
+	return s.listening
+}
+
+// Heartbeat sends a heartbeat message to WSJT-X.
 func (s *Server) Heartbeat(msg HeartbeatMessage) error {
 	msgBytes, _ := encodeHeartbeat(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to clear the band activity window, the RX frequency
-// window, or both.
+// Clear sends a message to WSJT-X to clear the band activity window, the RX frequency window, or
+// both.
 func (s *Server) Clear(msg ClearMessage) error {
 	msgBytes, _ := encodeClear(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Initiate a reply to an earlier decode. The decode message must have started
-// with CQ or QRZ.
+// Reply initiates a reply to an earlier decode. The decode message must have started with CQ or
+// QRZ.
 func (s *Server) Reply(msg ReplyMessage) error {
 	msgBytes, _ := encodeReply(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to close the program.
+// Close sends a message to WSJT-X to close the program.
 func (s *Server) Close(msg CloseMessage) error {
 	msgBytes, _ := encodeClose(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to replay QSOs in the Band Activity window.
+// Replay sends a message to WSJT-X to replay QSOs in the Band Activity window.
 func (s *Server) Replay(msg ReplayMessage) error {
 	msgBytes, _ := encodeReplay(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to halt transmission.
+// HaltTx sends a message to WSJT-X to halt transmission.
 func (s *Server) HaltTx(msg HaltTxMessage) error {
 	msgBytes, _ := encodeHaltTx(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to set the free text.
+// FreeText sends a message to WSJT-X to set the free text of the TX message.
 func (s *Server) FreeText(msg FreeTextMessage) error {
 	msgBytes, _ := encodeFreeText(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to set this station's Maidenhead grid.
+// Location sends a message to WSJT-X to set this station's Maidenhead grid.
 func (s *Server) Location(msg LocationMessage) error {
 	msgBytes, _ := encodeLocation(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to set callsign highlighting.
+// HighlightCallsign sends a message to WSJT-X to set callsign highlighting.
 func (s *Server) HighlightCallsign(msg HighlightCallsignMessage) error {
 	msgBytes, _ := encodeHighlightCallsign(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to switch to a different pre-defined configuration.
+// SwitchConfiguration sends a message to WSJT-X to switch to a different pre-defined configuration.
 func (s *Server) SwitchConfiguration(msg SwitchConfigurationMessage) error {
 	msgBytes, _ := encodeSwitchConfiguration(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)
 	return err
 }
 
-// Send a message to WSJT-X to change various configuration options.
+// Configure sends a message to WSJT-X to change various configuration options.
 func (s *Server) Configure(msg ConfigureMessage) error {
 	msgBytes, _ := encodeConfigure(msg)
 	_, err := s.conn.WriteTo(msgBytes, s.remoteAddr)


### PR DESCRIPTION
In order to accommodate forward and backward compatibility in the parser, parsing errors cannot be fatal or interrupt the main program. Instead, throw them in an error channel and let the client code decide what to do. Many parsing errors, like missing or extra fields, are not going to be reason to stop listening.