### PR TITLE
add support for QDataStream::Qt_5_4

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -127,7 +127,7 @@ func newEncoder() encoder {
 	e := encoder{bytes.NewBuffer(make([]byte, bufLen))}
 	e.buf.Reset()
 	e.encodeUint32(magic)
-	e.encodeUint32(schema)
+	e.encodeUint32(qDataStream5_2)
 	return e
 }
 

--- a/parser.go
+++ b/parser.go
@@ -37,7 +37,7 @@ func parseMessage(buffer []byte, length int) (interface{}, error) {
 	if err != nil {
 		return nil, ParseError
 	}
-	if sch != schema {
+	if !supportedSchemas[sch] {
 		return nil, fmt.Errorf("%w: got a schema version I wasn't expecting: %d", ParseError, sch)
 	}
 

--- a/server.go
+++ b/server.go
@@ -8,12 +8,19 @@ import (
 )
 
 const magic = 0xadbccbda
-const schema = 2
 const qDataStreamNull = 0xffffffff
 const bufLen = 1024
 const localhostAddr = "127.0.0.1"
 const multicastAddr = "224.0.0.1"
 const wsjtxPort = 2237
+
+const qDataStream5_2 uint32 = 2
+const qDataStream5_4 uint32 = 3
+
+var supportedSchemas = map[uint32]bool{
+	qDataStream5_2: true,
+	qDataStream5_4: true,
+}
 
 type Server struct {
 	ServingAddr net.Addr


### PR DESCRIPTION
QDataStream::Qt_5_4 is used by newer versions of WSJT-X. The difference to QDataStream::Qt_5_2 is not relevant for WSJT-X, so we can simply accept also this schema.

Fixes #39 