### PR TITLE
Add JTDX Support

### DIFF
--- a/integration/receive_test.go
+++ b/integration/receive_test.go
@@ -175,7 +175,7 @@ func (s *integrationTestSuite) TestReceiveCases() {
 			want: receiveResult{
 				msg: wsjtx.QsoLoggedMessage{
 					Id:             "JTDX",
-					DateTimeOff:    parseTime("2026-01-05 04:31:00 +0000 UTC"),
+					DateTimeOff:    time.Date(2026, time.January, 5, 12, 31, 0, 0, time.Local),
 					DxCall:         "T3ST",
 					DxGrid:         "JK73",
 					TxFrequency:    14075500,
@@ -185,7 +185,7 @@ func (s *integrationTestSuite) TestReceiveCases() {
 					TxPower:        "20",
 					Comments:       "Distance: 10773 km",
 					Name:           "Smith",
-					DateTimeOn:     parseTime("2026-01-05 04:29:47 +0000 UTC"),
+					DateTimeOn:     time.Date(2026, time.January, 5, 12, 29, 47, 0, time.Local),
 					OperatorCall:   "BG5VLI",
 					MyCall:         "BG5VLI",
 					MyGrid:         "OL94",

--- a/integration/receive_test.go
+++ b/integration/receive_test.go
@@ -32,6 +32,17 @@ func (s *integrationTestSuite) TestReceiveCases() {
 			}, nil},
 		},
 		{
+			name: "Heartbeat (JTDX)",
+			args: decode(`adbccbda0000000200000000000000044a5444580000000300000007322e322e313539`),
+			want: receiveResult{
+				wsjtx.HeartbeatMessage{
+					Id:        "JTDX",
+					MaxSchema: 3,
+					Version:   "2.2.159",
+				}, nil,
+			},
+		},
+		{
 			name: "Status 2.2.2",
 			args: decode(`adbccbda00000002000000010000000657534a542d5800000000006bf0d000000003465438ffffffff000000032d313500000003465438000000000003730000079e000000054b3053574500000006444d37394c56ffffffff00ffffffff0000ffffffffffffffff0000000744656661756c74`),
 			want: receiveResult{wsjtx.StatusMessage{
@@ -87,6 +98,31 @@ func (s *integrationTestSuite) TestReceiveCases() {
 			}, nil},
 		},
 		{
+			name: "Status (JTDX)",
+			args: decode(`adbccbda0000000200000001000000044a5444580000000000d6c09000000003465438ffffffff000000022d33000000034654380000010000083a0000083a00000006424735564c49000000044f4c3934ffffffff00ffffffff0000`),
+			want: receiveResult{
+				wsjtx.StatusMessage{
+					Id:            "JTDX",
+					DialFrequency: 14074000,
+					Mode:          "FT8",
+					DxCall:        "",
+					Report:        "-3",
+					TxMode:        "FT8",
+					TxEnabled:     false,
+					Transmitting:  false,
+					Decoding:      true,
+					RxDF:          2106,
+					TxDF:          2106,
+					DeCall:        "BG5VLI",
+					DeGrid:        "OL94",
+					DxGrid:        "",
+					TxWatchdog:    false,
+					SubMode:       "",
+					FastMode:      false,
+				}, nil,
+			},
+		},
+		{
 			name: "Decode",
 			args: decode(`adbccbda00000002000000020000000657534a542d58010259baf8fffffffb3fc99999a000000000000516000000017e0000000e4a4132454a50204e3442502037330000`),
 			want: receiveResult{wsjtx.DecodeMessage{
@@ -134,6 +170,30 @@ func (s *integrationTestSuite) TestReceiveCases() {
 			}, nil},
 		},
 		{
+			name: "QSO Logged (JTDX)",
+			args: decode(`adbccbda0000000200000005000000044a5444580000000000258d7602af9185000000000454335354000000044a4b37330000000000d6c66c00000003465438000000032d3135000000032d31350000000232300000001244697374616e63653a203130373733206b6d00000005536d6974680000000000258d7602ae760d0000000006424735564c4900000006424735564c49000000044f4c3934`),
+			want: receiveResult{
+				msg: wsjtx.QsoLoggedMessage{
+					Id:             "JTDX",
+					DateTimeOff:    parseTime("2026-01-05 12:31:00 +0800 CST"),
+					DxCall:         "T3ST",
+					DxGrid:         "JK73",
+					TxFrequency:    14075500,
+					Mode:           "FT8",
+					ReportSent:     "-15",
+					ReportReceived: "-15",
+					TxPower:        "20",
+					Comments:       "Distance: 10773 km",
+					Name:           "Smith",
+					DateTimeOn:     parseTime("2026-01-05 12:29:47 +0800 CST"),
+					OperatorCall:   "BG5VLI",
+					MyCall:         "BG5VLI",
+					MyGrid:         "OL94",
+				},
+				err: nil,
+			},
+		},
+		{
 			name: "Close",
 			args: decode(`adbccbda00000002000000060000000657534a542d58`),
 			want: receiveResult{wsjtx.CloseMessage{
@@ -154,6 +214,23 @@ func (s *integrationTestSuite) TestReceiveCases() {
 				Callsign:  "K6TGW",
 				Grid:      "CM95",
 				Power:     23,
+				OffAir:    false,
+			}, nil},
+		},
+		{
+			name: "WSPR Decode (JTDX)",
+			args: decode(`adbccbda000000020000000a000000044a544458010277b6c0ffffffe43fe00000000000000000000000d71b1700000000000000064a41354e564e00000004504d37340000001e00`),
+			want: receiveResult{wsjtx.WSPRDecodeMessage{
+				Id:        "JTDX",
+				New:       true,
+				Time:      41400000,
+				Snr:       -28,
+				DeltaTime: 0.5,
+				Frequency: 14097175,
+				Drift:     0,
+				Callsign:  "JA5NVN",
+				Grid:      "PM74",
+				Power:     30,
 				OffAir:    false,
 			}, nil},
 		},

--- a/integration/receive_test.go
+++ b/integration/receive_test.go
@@ -175,7 +175,7 @@ func (s *integrationTestSuite) TestReceiveCases() {
 			want: receiveResult{
 				msg: wsjtx.QsoLoggedMessage{
 					Id:             "JTDX",
-					DateTimeOff:    parseTime("2026-01-05 12:31:00 +0800 CST"),
+					DateTimeOff:    parseTime("2026-01-05 04:31:00 +0000 UTC"),
 					DxCall:         "T3ST",
 					DxGrid:         "JK73",
 					TxFrequency:    14075500,
@@ -185,7 +185,7 @@ func (s *integrationTestSuite) TestReceiveCases() {
 					TxPower:        "20",
 					Comments:       "Distance: 10773 km",
 					Name:           "Smith",
-					DateTimeOn:     parseTime("2026-01-05 12:29:47 +0800 CST"),
+					DateTimeOn:     parseTime("2026-01-05 04:29:47 +0000 UTC"),
 					OperatorCall:   "BG5VLI",
 					MyCall:         "BG5VLI",
 					MyGrid:         "OL94",

--- a/integration/receive_test.go
+++ b/integration/receive_test.go
@@ -231,7 +231,6 @@ func (s *integrationTestSuite) TestReceiveCases() {
 				Callsign:  "JA5NVN",
 				Grid:      "PM74",
 				Power:     30,
-				OffAir:    false,
 			}, nil},
 		},
 		{

--- a/parser.go
+++ b/parser.go
@@ -118,6 +118,8 @@ func (p *parser) parseHeartbeat() (HeartbeatMessage, error) {
 	heartbeatMessage.Id, err = p.parseUtf8()
 	heartbeatMessage.MaxSchema, err = p.parseUint32()
 	heartbeatMessage.Version, err = p.parseUtf8()
+
+	// JTDX Packet
 	if !p.isDataAvailable() {
 		return heartbeatMessage, err
 	}

--- a/parser.go
+++ b/parser.go
@@ -118,6 +118,9 @@ func (p *parser) parseHeartbeat() (HeartbeatMessage, error) {
 	heartbeatMessage.Id, err = p.parseUtf8()
 	heartbeatMessage.MaxSchema, err = p.parseUint32()
 	heartbeatMessage.Version, err = p.parseUtf8()
+	if !p.isDataAvailable() {
+		return heartbeatMessage, err
+	}
 	heartbeatMessage.Revision, err = p.parseUtf8()
 	return heartbeatMessage, err
 }
@@ -142,6 +145,12 @@ func (p *parser) parseStatus() (StatusMessage, error) {
 	statusMessage.TxWatchdog, err = p.parseBool()
 	statusMessage.SubMode, err = p.parseUtf8()
 	statusMessage.FastMode, err = p.parseBool()
+
+	// A JTDX Format packet (Tx first, bool)
+	if (p.length - p.cursor) == 1 {
+		_, _ = p.parseBool()
+		return statusMessage, err
+	}
 	statusMessage.SpecialOperationMode, err = p.parseUint8()
 	statusMessage.FrequencyTolerance, err = p.parseUint32()
 	statusMessage.TRPeriod, err = p.parseUint32()
@@ -191,9 +200,18 @@ func (p *parser) parseQsoLogged() (QsoLoggedMessage, error) {
 	qsoLoggedMessage.OperatorCall, err = p.parseUtf8()
 	qsoLoggedMessage.MyCall, err = p.parseUtf8()
 	qsoLoggedMessage.MyGrid, err = p.parseUtf8()
+
+	// JTDX Packet
+	if !p.isDataAvailable() {
+		return qsoLoggedMessage, err
+	}
 	qsoLoggedMessage.ExchangeSent, err = p.parseUtf8()
 	qsoLoggedMessage.ExchangeReceived, err = p.parseUtf8()
-	qsoLoggedMessage.ADIFPropagationMode, err = p.parseUtf8()
+
+	// Older WSJT-X packet doesn't have Propagation Mode
+	if p.isDataAvailable() {
+		qsoLoggedMessage.ADIFPropagationMode, err = p.parseUtf8()
+	}
 	return qsoLoggedMessage, err
 }
 
@@ -217,6 +235,11 @@ func (p *parser) parseWsprDecode() (WSPRDecodeMessage, error) {
 	wsprDecodeMessage.Callsign, err = p.parseUtf8()
 	wsprDecodeMessage.Grid, err = p.parseUtf8()
 	wsprDecodeMessage.Power, err = p.parseInt32()
+
+	// JTDX Packet
+	if !p.isDataAvailable() {
+		return wsprDecodeMessage, err
+	}
 	wsprDecodeMessage.OffAir, err = p.parseBool()
 	return wsprDecodeMessage, err
 }
@@ -326,4 +349,8 @@ func (p *parser) parseQDateTime() (time.Time, error) {
 		return value, fmt.Errorf("got a timespec I wasn't expecting: %d", timespec)
 	}
 	return value, err
+}
+
+func (p *parser) isDataAvailable() bool {
+	return p.cursor < p.length
 }


### PR DESCRIPTION
Hello @xylo04,

Thank you for sharing this awesome project with us!

The current code seems to have decoding errors for JTDX messages:
<img width="500"  alt="error" src="https://github.com/user-attachments/assets/35e6afde-e0ac-4f24-8d15-44275ac268e7" />

After reviewing the [JTDX source code](https://github.com/jtdx-project/jtdx/blob/master/NetworkMessage.hpp), I noticed that its message protocol is very similar to WSJT-X's. It seems that with a few adjustments to the existing code, we could add support for JTDX!

Here is a demonstration of the decoding working correctly after the fix:
https://github.com/user-attachments/assets/f76462b5-2713-4f29-b35b-b1e0727da80a

I've submitted the PR with proposed fix - would you mind taking a look when you have a moment?

Wishing you a Happy New Year!
SydneyOwl