### PR TITLE
Added server Shutdown command

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/leemcloughlin/jdn v0.0.0-20201102080031-6f88db6a6bf2 h1:CdyD5OzAIzNFzpJ9WQRjJWj4pVRxZ9v15xdHnhvUPdw=
 github.com/leemcloughlin/jdn v0.0.0-20201102080031-6f88db6a6bf2/go.mod h1:LAowglanJPLb6WYSx3D1Ht/XE54OGIr0i4mz9kdbXrs=
-github.com/mazznoer/csscolorparser v0.1.6 h1:uK6p5zBA8HaQZJSInHgHVmkVBodUAy+6snSmKJG7pqA=
-github.com/mazznoer/csscolorparser v0.1.6/go.mod h1:OQRVvgCyHDCAquR1YWfSwwaDcM0LhnSffGnlbOew/3I=
-github.com/mazznoer/csscolorparser v0.1.7 h1:cmFIGBNVHG9QLCBco13J4xA6JVf6Kim9Zn4ZXMrhuNg=
-github.com/mazznoer/csscolorparser v0.1.7/go.mod h1:OQRVvgCyHDCAquR1YWfSwwaDcM0LhnSffGnlbOew/3I=
 github.com/mazznoer/csscolorparser v0.1.8 h1:i7w3wHW99d0q0KZv1ONkU/efXFAKcw1mgEgW6gj8KUA=
 github.com/mazznoer/csscolorparser v0.1.8/go.mod h1:OQRVvgCyHDCAquR1YWfSwwaDcM0LhnSffGnlbOew/3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/server.go
+++ b/server.go
@@ -27,7 +27,6 @@ type Server struct {
 	conn        *net.UDPConn
 	remoteAddr  *net.UDPAddr
 	listening   bool
-	opened      bool
 }
 
 var NotConnectedError = fmt.Errorf("haven't heard from wsjtx yet, don't know where to send commands")
@@ -64,25 +63,21 @@ func MakeServerGiven(ipAddr net.IP, port uint) (Server, error) {
 	if conn == nil {
 		return Server{}, errors.New("wsjtx udp connection not opened")
 	}
-	return Server{conn.LocalAddr(), conn, nil, false, true}, nil
+	return Server{conn.LocalAddr(), conn, nil, false}, nil
 }
 
 func (s *Server) LocalAddr() net.Addr {
 	return s.conn.LocalAddr()
 }
 
-// Shutdown will close the UDP connection to communicate with WSJT-X and set the server
-// connection to nil as well as setting the opened flag to false. The ListenToWsjtx
-// routine will detect that the connection is nill, and will return with no error
-// if the opened flag is false. This will close the channels notifying the client
-// that the ListenToWsjtx has stopped due to the Shutdown command.
+// Shutdown will close the UDP connection to communicate with WSJT-X. The
+// ListenToWsjtx routine will detect that the connection is closed when it
+// receives a net.ErrorClose error from reading the UDP connection
 func (s *Server) Shutdown() error {
 	err := s.conn.Close()
 	if err != nil {
 		return errors.New("problem closing UDP connection")
 	}
-	s.opened = false
-	s.conn = nil
 	return nil
 }
 
@@ -98,15 +93,13 @@ func (s *Server) ListenToWsjtx(c chan interface{}, e chan error) {
 	for {
 		b := make([]byte, bufLen)
 		if s.conn == nil {
-			if !s.opened {
-				e <- errors.New("wsjtx connection is nil")
-			}
+			e <- errors.New("wsjtx connection is nil")
 			s.listening = false
 			return
 		}
 		length, rAddr, err := s.conn.ReadFromUDP(b)
 		if err != nil {
-			if !s.opened {
+			if !errors.Is(err, net.ErrClosed) {
 				e <- fmt.Errorf("problem reading from wsjtx: %w", err)
 			}
 			s.listening = false

--- a/server.go
+++ b/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	conn        *net.UDPConn
 	remoteAddr  *net.UDPAddr
 	listening   bool
+	opened      bool
 }
 
 var NotConnectedError = fmt.Errorf("haven't heard from wsjtx yet, don't know where to send commands")
@@ -63,11 +64,26 @@ func MakeServerGiven(ipAddr net.IP, port uint) (Server, error) {
 	if conn == nil {
 		return Server{}, errors.New("wsjtx udp connection not opened")
 	}
-	return Server{conn.LocalAddr(), conn, nil, false}, nil
+	return Server{conn.LocalAddr(), conn, nil, false, true}, nil
 }
 
 func (s *Server) LocalAddr() net.Addr {
 	return s.conn.LocalAddr()
+}
+
+// Shutdown will close the UDP connection to communicate with WSJT-X and set the server
+// connection to nil as well as setting the opened flag to false. The ListenToWsjtx
+// routine will detect that the connection is nill, and will return with no error
+// if the opened flag is false. This will close the channels notifying the client
+// that the ListenToWsjtx has stopped due to the Shutdown command.
+func (s *Server) Shutdown() error {
+	err := s.conn.Close()
+	if err != nil {
+		return errors.New("problem closing UDP connection")
+	}
+	s.opened = false
+	s.conn = nil
+	return nil
 }
 
 // ListenToWsjtx listens for messages from WSJT-X. When heard, the messages are parsed and then
@@ -82,13 +98,17 @@ func (s *Server) ListenToWsjtx(c chan interface{}, e chan error) {
 	for {
 		b := make([]byte, bufLen)
 		if s.conn == nil {
-			e <- errors.New("wsjtx connection is nil")
+			if !s.opened {
+				e <- errors.New("wsjtx connection is nil")
+			}
 			s.listening = false
 			return
 		}
 		length, rAddr, err := s.conn.ReadFromUDP(b)
 		if err != nil {
-			e <- fmt.Errorf("problem reading from wsjtx: %w", err)
+			if !s.opened {
+				e <- fmt.Errorf("problem reading from wsjtx: %w", err)
+			}
 			s.listening = false
 			return
 		}


### PR DESCRIPTION
I needed a clean shutdown of the ListenToWsjtx go routine for the TUI application I am working on. I added the Shutdown command to the server.go file which will close the UDP 'connection' to WSJT-X, set the connection to nil, and set a new boolean flag called 'opened' to false. This way the ListenToWsjtx routine will detect the connection as closed on purpose and just return. This closes the open channels which notifies the TUI application that the shutdown of the listener was done.